### PR TITLE
Add "all" mode for file import with enhanced media processing

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -144,29 +144,7 @@ func createDocument(c *client.Client, externalID string, name string, fileData [
 
 	metadata["external_id"] = externalID
 
-	var mode *client.Mode
-	switch config.Mode {
-	case "all":
-		mode = &client.Mode{
-			Static: "hi_res",
-			Audio:  true,
-			Video:  "audio_video",
-		}
-	case "hi_res":
-		mode = &client.Mode{
-			Static: "hi_res",
-		}
-	case "fast":
-		mode = &client.Mode{
-			Static: "fast",
-		}
-	case "":
-		mode = nil
-	default:
-		return fmt.Errorf("unknown mode: %s", config.Mode)
-	}
-
-	doc, err := c.CreateDocument(config.Partition, name, fileData, fileName, metadata, mode)
+	doc, err := c.CreateDocument(config.Partition, name, fileData, fileName, metadata, config.Mode)
 	if err != nil {
 		return err
 	}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -17,6 +17,12 @@ type Client struct {
 	httpClient *http.Client
 }
 
+type Mode struct {
+	Static string `json:"static,omitempty"`
+	Audio  bool   `json:"audio,omitempty"`
+	Video  string `json:"video,omitempty"`
+}
+
 type Document struct {
 	ID       string                 `json:"id"`
 	Name     string                 `json:"name"`
@@ -156,7 +162,7 @@ func (c *Client) DeleteDocument(id string) error {
 
 // CreateDocument uploads a file using multipart form data
 // The mode parameter can be set to "hi_res" for higher quality processing or "fast" for faster processing
-func (c *Client) CreateDocument(partition string, name string, fileData []byte, fileName string, metadata map[string]interface{}, mode string) (*Document, error) {
+func (c *Client) CreateDocument(partition string, name string, fileData []byte, fileName string, metadata map[string]interface{}, mode *Mode) (*Document, error) {
 	// Create a new multipart writer
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
@@ -183,8 +189,12 @@ func (c *Client) CreateDocument(partition string, name string, fileData []byte, 
 	}
 
 	// Add the mode field if provided
-	if mode != "" {
-		if err := writer.WriteField("mode", mode); err != nil {
+	if mode != nil {
+		modeJSON, err := json.Marshal(mode)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal mode: %v", err)
+		}
+		if err := writer.WriteField("mode", string(modeJSON)); err != nil {
 			return nil, fmt.Errorf("failed to write mode field: %v", err)
 		}
 	}


### PR DESCRIPTION
This commit implements a new processing mode called "all" for the import command. It enhances the existing mode options (fast, hi_res) with a comprehensive option that enables:

* High resolution processing for static content
* Audio processing support
* Combined audio and video processing for video files

The change also replaces the simple string mode parameter with a structured Mode object that can specify different processing settings for different media types.